### PR TITLE
fix: import jest from `@jest/globals`

### DIFF
--- a/packages/@lwc/jest-transformer/src/transforms/__tests__/apex-continuation-scoped-import.test.js
+++ b/packages/@lwc/jest-transformer/src/transforms/__tests__/apex-continuation-scoped-import.test.js
@@ -13,6 +13,7 @@ describe('@salesforce/apexContinuation import', () => {
         import myMethod from '@salesforce/apexContinuation/FooController.fooMethod';
     `,
         `
+        import { jest } from '@jest/globals';
         let myMethod;
 
         try {
@@ -33,6 +34,7 @@ describe('@salesforce/apexContinuation import', () => {
     `,
         `
         import { otherNamed } from './something-valid';
+        import { jest } from '@jest/globals';
         let myMethod;
 
         try {

--- a/packages/@lwc/jest-transformer/src/transforms/__tests__/apex-scoped-import.test.js
+++ b/packages/@lwc/jest-transformer/src/transforms/__tests__/apex-scoped-import.test.js
@@ -13,6 +13,7 @@ describe('@salesforce/apex import', () => {
         import myMethod from '@salesforce/apex/FooController.fooMethod';
     `,
         `
+        import { jest } from '@jest/globals';
         let myMethod;
 
         try {
@@ -33,6 +34,7 @@ describe('@salesforce/apex import', () => {
     `,
         `
         import { otherNamed } from './something-valid';
+        import { jest } from '@jest/globals';
         let myMethod;
 
         try {

--- a/packages/@lwc/jest-transformer/src/transforms/utils.js
+++ b/packages/@lwc/jest-transformer/src/transforms/utils.js
@@ -71,6 +71,7 @@ function stringScopedImportTransform(t, path, importIdentifier, fallbackData) {
  * shared.
  */
 const resolvedPromiseTemplate = babelTemplate(`
+    import { jest } from '@jest/globals';
     let RESOURCE_NAME;
     try {
         RESOURCE_NAME = require(IMPORT_SOURCE).default;


### PR DESCRIPTION
I think an improvement to https://github.com/salesforce/lwc-test/pull/260 would be to import `jest` from `@jest/globals`. Otherwise this will not work in projects where [`injectGlobals`](https://jestjs.io/docs/configuration#injectglobals-boolean) is set to `false`.